### PR TITLE
ブラウザ差分をなくすためフォントを統一

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -3,6 +3,9 @@ body {
   margin: 0;
   padding: 0;
   font-size: 1.5em;
+  /* ブラウザ依存のフォント差異を抑えるためフォントを明示的に指定 */
+  font-family: 'Noto Sans JP', -apple-system, BlinkMacSystemFont,
+               'Segoe UI', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
 }
 
 #header-area {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <title>休日当番医(金沢市)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Bootstrapの読み込みは削除済み -->
+  <!-- Google Fonts を利用してフォントを統一 -->
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
   <link href="custom.css" rel="stylesheet">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/encoding-japanese/1.0.30/encoding.min.js"></script>
 </head>


### PR DESCRIPTION
## 変更点
- Google Fonts を読み込み `Noto Sans JP` を利用するように修正
- `custom.css` に `font-family` を追加し、ブラウザ依存のフォント差異を抑制

## テスト
- `npm test` を実行（`package.json` が無いため失敗）【2a2a88†L1-L15】
- `pytest -q` を実行（テスト無し）【58f440†L1-L4】

------
https://chatgpt.com/codex/tasks/task_e_688abc6b32b4832180bd0a89a2c11adf